### PR TITLE
Run fact graph tests on all pushes

### DIFF
--- a/.github/workflows/run-scala-factgraph-tests.yml
+++ b/.github/workflows/run-scala-factgraph-tests.yml
@@ -4,7 +4,8 @@ on:
   push:
     paths:
       - 'direct-file/fact-graph-scala/**'
-    branches: [main]
+    branches: 
+      - "**"
   pull_request:
     paths:
       - 'direct-file/fact-graph-scala/**'


### PR DESCRIPTION
## Description

Right now, if you push a change that fails CI, and then push a fix, CI doesn't check your work again, unless you open a new PR. This should let me see if a new push fixes an issue.

### What changed

Runs scala fact graph tests on all pushes that update the directory, not just pushes to main.

### Motivation and context

This should make it easier to see if a new push to a branch with an open PR fixes all issues.

## Tests

### Scala tests (if applicable)

N/A

### Fact dictionary tests (for all changes)

N/A

### Manual tests

Will need to verify that CI still runs correctly on changes to fact-graph-scala 

## Is there anything reviewers should look at carefully?

No?

## Are there any loose ends or TODO items for the future?

Just testing that this still works on a branch with an open PR.