### PR TITLE
Add tests to CI for fact dictionary

### DIFF
--- a/.github/workflows/run-fact-dictionary-tests.yml
+++ b/.github/workflows/run-fact-dictionary-tests.yml
@@ -1,0 +1,40 @@
+name: Run fact dictionary tests
+
+on:
+  push:
+    paths:
+      - '/direct-file/backend/src/main/resources/tax/**'
+      - '/direct-file/backend/src/test/**'
+      - '/direct-file/df-client/df-client-app/src/test/**'
+    branches:
+      - '**'
+  pull_request:
+    paths:
+      - '/direct-file/backend/src/main/resources/tax/**'
+      - '/direct-file/backend/src/test/**'
+      - '/direct-file/df-client/df-client-app/src/test/**'
+    branches: [main]
+
+jobs:
+  fact-dictionary-tests:
+    name: Run fact dictionary tests
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: /direct-file/df-client/df-client-app/src/test
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18.20.4'
+
+      - name: Install node
+        uses: ../../../npm install
+
+      - name: Run fact dictionary tests
+        run: npm run test factDictionaryTests


### PR DESCRIPTION
## Description

These should run fact dictionary tests on PRs to main and on changes to either the fact dictionary modules or their tests.

### What changed

Uses Github actions to automatically test pushes and PRs

### Motivation and context

Manual testing is such a drag. Still valuable, but CI makes everything so much better.

## Tests

### Scala tests (if applicable)

N/A

### Fact dictionary tests (for all changes)

N/A

### Manual tests

N/A - just going to change something in a follow on PR and see if these run as expected.

## Is there anything reviewers should look at carefully?

Everything 🙃 

## Are there any loose ends or TODO items for the future?

Check to see if this works