### PR TITLE
Fix build errors due to formatting

### DIFF
--- a/direct-file/backend/src/main/resources/tax/ctcOdc.xml
+++ b/direct-file/backend/src/main/resources/tax/ctcOdc.xml
@@ -192,7 +192,8 @@
     <Fact path="/maxCtcAmount">
       <Name>Maximum child tax credit amount</Name>
       <Description>The maximum child tax credit per child. Established in 26 U.S. Code § 24.
-        Under current legislation, this reduces to $1,000 for TY 2026. Can be found in instructions
+        Under current legislation,
+        this reduces to $1,000 for TY 2026. Can be found in instructions
         for Schedule 8812.</Description>
       <TaxYear>2024</TaxYear>
 
@@ -250,7 +251,8 @@
     <Fact path="/totalPotentialOdc">
       <Name>Total potential ODC</Name>
       <Description>The maximum amount of the Credit for Other Dependents that could be claimed.
-        Established in 26 U.S. Code § 24. Under current legislation, ODC expires as a credit in TY 2026.
+        Established in 26 U.S.
+        Code § 24. Under current legislation, ODC expires as a credit in TY 2026.
         Reported on line 7 of Schedule 8812.</Description>
       <TaxYear>2024</TaxYear>
       <Export mef="true" />
@@ -317,8 +319,10 @@
     <Fact path="/dependentCreditPhaseoutThreshold">
       <Name>Dependent credit phaseout threshold</Name>
       <Description>The MAGI threshold at which the dependent credits begin to phaseout.
-        Set in 26 U.S. Code § 24. Under current legislation, amounts shown here persist through TY2025
-        and then revert to $110,000 MFJ / $75,000 not married / $55,000 MFS for TY 2026.
+        Set in 26 U.S. Code § 24. Under
+        current legislation, amounts shown here persist through TY2025
+        and then revert to $110,000 MFJ / $75,000 not
+        married / $55,000 MFS for TY 2026.
         Reported on line 9 of Schedule 8812.</Description>
       <Export mef="true" />
       <TaxYear>2024</TaxYear>
@@ -811,8 +815,10 @@
     <Fact path="/maxActcAmount">
       <Name>Maximum additional child tax credit amount</Name>
       <Description>The maximum additional tax credit per child. Established in 26 U.S. Code § 24.
-        This is adjusted for inflation annually, with special rules applied through TY 2025.
-        See inflation adjustment Rev Proc section .05 Child Tax Credit §24(d)(1)(A) for annual amounts.
+        This is adjusted for
+        inflation annually, with special rules applied through TY 2025.
+        See inflation adjustment Rev Proc section .05
+        Child Tax Credit §24(d)(1)(A) for annual amounts.
       </Description>
       <TaxYear>2024</TaxYear>
 
@@ -862,7 +868,8 @@
     <Fact path="/actcRefundabilityThreshold">
       <Name>Additional CTC refundability threshold</Name>
       <Description>The amount of earned income that must be exceeded in order to receive the
-        refundable additional child tax credit. Set in 26 U.S. Code § 24. Under current legislation,
+        refundable additional child
+        tax credit. Set in 26 U.S. Code § 24. Under current legislation,
         reverts to $3,000 in TY 2026.</Description>
       <TaxYear>2024</TaxYear>
 

--- a/direct-file/backend/src/main/resources/tax/familyAndHousehold.xml
+++ b/direct-file/backend/src/main/resources/tax/familyAndHousehold.xml
@@ -3857,8 +3857,10 @@
     <Fact path="/familyAndHousehold/*/eligibleCtc">
       <Name>Eligible for the Child Tax Credit</Name>
       <Description>The dependent is eligible for the Child Tax Credit (CTC). Eligibility rules are
-        established in 26 U.S. Code § 24. Under current legislation, the requirement to have a SSN 
-        and include it on the return expires after TY 2025.
+        established in 26 U.S.
+        Code § 24. Under current legislation, the requirement to have a SSN
+        and include it on the return expires after TY
+        2025.
         See instructions for Schedule 8812 for current tax year guidance.</Description>
       <TaxYear>2024</TaxYear>
       <Export downstreamFacts="true" />


### PR DESCRIPTION
## Description

### What changed

Fix issues caused by spotless throwing errors on build. Fixed by running `mvn spotless:apply` from backend directory.

### Motivation and context

The main build was broken (oops). Running `docker-compose up -d --build` failed.

## Tests

### Scala tests (if applicable)

N/A

### Fact dictionary tests (for all changes)

N/A

### Manual tests

Added CI test to ensure spotless won't complain; manually ran `docker-compose up -d --build` to verify build is working again.

## Is there anything reviewers should look at carefully?

No

## Are there any loose ends or TODO items for the future?

Eventually, could be nice to have CI for all the build steps, but that will add a lot of time to each run. :/