### PR TITLE
Minor fact maintenance

### DIFF
--- a/direct-file/backend/src/main/resources/pdf/2024/IRS1040/en/configuration.yml
+++ b/direct-file/backend/src/main/resources/pdf/2024/IRS1040/en/configuration.yml
@@ -111,7 +111,7 @@ form:
       f2_06[0]: /line8OfSchedule3
       f2_07[0]: /nonRefundableCredits
       f2_08[0]: /taxLessNonRefundableCredits
-      f2_09[0]: /line21OfSchedule2
+      f2_09[0]: /totalOtherTaxes
       f2_10[0]: /totalTax
       f2_11[0]: /formW2Withholding
       f2_12[0]: /form1099Withholding

--- a/direct-file/backend/src/main/resources/pdf/2024/IRS1040/es/configuration.yml
+++ b/direct-file/backend/src/main/resources/pdf/2024/IRS1040/es/configuration.yml
@@ -114,7 +114,7 @@ form:
       f2_06[0]: /line8OfSchedule3
       f2_07[0]: /nonRefundableCredits
       f2_08[0]: /taxLessNonRefundableCredits
-      f2_09[0]: /line21OfSchedule2
+      f2_09[0]: /totalOtherTaxes
       f2_10[0]: /totalTax
       f2_11[0]: /formW2Withholding
       f2_12[0]: /form1099Withholding

--- a/direct-file/backend/src/main/resources/pdf/2024/IRS1040SR/en/configuration.yml
+++ b/direct-file/backend/src/main/resources/pdf/2024/IRS1040SR/en/configuration.yml
@@ -114,7 +114,7 @@ form:
       f2_15[0]: /line8OfSchedule3
       f2_16[0]: /nonRefundableCredits
       f2_17[0]: /taxLessNonRefundableCredits
-      f2_18[0]: /line21OfSchedule2
+      f2_18[0]: /totalOtherTaxes
       f2_19[0]: /totalTax
       f2_20[0]: /formW2Withholding
       f2_21[0]: /form1099Withholding

--- a/direct-file/backend/src/main/resources/pdf/2024/IRS1040SR/es/configuration.yml
+++ b/direct-file/backend/src/main/resources/pdf/2024/IRS1040SR/es/configuration.yml
@@ -111,7 +111,7 @@ form:
       f2_25[0]: /line8OfSchedule3
       f2_26[0]: /nonRefundableCredits
       f2_27[0]: /taxLessNonRefundableCredits
-      f2_28[0]: /line21OfSchedule2
+      f2_28[0]: /totalOtherTaxes
       f2_29[0]: /totalTax
       f2_30[0]: /formW2Withholding
       f2_31[0]: /form1099Withholding

--- a/direct-file/backend/src/main/resources/tax/schedule2.xml
+++ b/direct-file/backend/src/main/resources/tax/schedule2.xml
@@ -13,6 +13,16 @@
       </Derived>
     </Fact>
 
+    <Fact path="/totalOtherTaxes">
+      <Name>Total other taxes</Name>
+      <Description>Other taxes, including self-employment.
+        Reported on Line 21 of schedule 2 and Form 1040 line 23.
+      </Description>
+      <Derived>
+        <Dollar>0</Dollar>
+      </Derived>
+    </Fact>
+
     <Fact path="/totalAdditionalTaxesOwed">
       <Description>Line 3 of schedule 2 for line 17 of form 1040</Description>
       <Export mef="true" downstreamFacts="true" />

--- a/direct-file/backend/src/main/resources/tax/taxCalculations.xml
+++ b/direct-file/backend/src/main/resources/tax/taxCalculations.xml
@@ -1385,10 +1385,11 @@
       </Derived>
     </Fact>
 
-    <Fact path="/line21OfSchedule2">
-      <Name>Line 21 of Schedule 2</Name>
-      <Description>Other taxes, including self-employment Line 21 of schedule 2 for line 23 of form
-        1040</Description>
+    <Fact path="/totalOtherTaxes">
+      <Name>Total other taxes</Name>
+      <Description>Other taxes, including self-employment.
+        Reported on Line 21 of schedule 2 and Form 1040 line 23.
+      </Description>
       <Derived>
         <Dollar>0</Dollar>
       </Derived>

--- a/direct-file/backend/src/main/resources/tax/taxCalculations.xml
+++ b/direct-file/backend/src/main/resources/tax/taxCalculations.xml
@@ -1385,16 +1385,6 @@
       </Derived>
     </Fact>
 
-    <Fact path="/totalOtherTaxes">
-      <Name>Total other taxes</Name>
-      <Description>Other taxes, including self-employment.
-        Reported on Line 21 of schedule 2 and Form 1040 line 23.
-      </Description>
-      <Derived>
-        <Dollar>0</Dollar>
-      </Derived>
-    </Fact>
-
     <Fact path="/totalTax">
       <Name>Total tax</Name>
       <Description>Total tax as reported on line 24 of Form 1040.</Description>


### PR DESCRIPTION
## Description

Rename /line21ofSchedule2 to a more semantically pleasing name and move it to the Schedule 2 module for easier future maintenance. That fact isn't actually used yet, so this is super low risk.

### What changed

Renamed /line21ofSchedule2 to a more semantically pleasing name and move it to the Schedule 2 module

### Motivation and context

A good semantic name will make this much easier to make sense of when we put the fact into use.

## Tests

### Scala tests (if applicable)

N/A

### Fact dictionary tests (for all changes)

- [x] I have added fact dictionary tests as appropriate.
- [x] I have run `npm run generate-fact-dictionary` from `/direct-file-factgraph/direct-file/df-client/df-client-app`
- [x] I have run `npm run test factDictionaryTests` from `/direct-file-factgraph/direct-file/df-client/df-client-app/src/test` and all tests pass.

### Manual tests

None needed - low risk.

## Is there anything reviewers should look at carefully?

No

## Are there any loose ends or TODO items for the future?

Use the facts - coming soon.