### PR TITLE
Add facts to support Part I of Form 8959 (Additional Medicare Tax)

### DIFF
--- a/direct-file/backend/src/main/resources/tax/additionalMedicareTax.xml
+++ b/direct-file/backend/src/main/resources/tax/additionalMedicareTax.xml
@@ -80,6 +80,79 @@
       </Derived>
     </Fact>
 
+    <Fact path="/additionalMedicareTaxRate">
+      <Name>Rate of the additional medicare tax on wages</Name>
+      <Description>The rate of Additional Medicare Tax with respect to wages received.
+        Defined in 26 CFR § 31.3101-2
+      </Description>
+      <Derived>
+        <Rational>9/1000</Rational>
+      </Derived>
+    </Fact>
+
+    <Fact path="/regularMedicareTaxWithholdingRate">
+      <Name>Rate of the regular medicare tax on wages</Name>
+      <Description>The rate of Medicare Tax (a.k.a Hospital Insurance) with respect to wages received
+        Defined in 26 CFR §
+        31.3101-2
+      </Description>
+      <Derived>
+        <Rational>145/10000</Rational>
+      </Derived>
+    </Fact>
+
+    <Fact path="/unreportedTipsSubjectToMedicareTax">
+      <Description>Unreported tips subject to Medicare tax. Found on form 4137 line 6.
+        Currently not supported. Assumes
+        that a question verifies this form of
+        income does not apply to the taxpayer.
+        Will need to be updated when/if
+        unreported tips are in scope.
+        May also be affected by pending legislation on whether tips are taxable.
+      </Description>
+      <TaxYear>2024</TaxYear>
+      <Derived>
+        <Dollar>0</Dollar>
+      </Derived>
+    </Fact>
+
+    <Fact path="/wagesWithNoSSOrMedicareTaxWithholdings">
+      <Description>Wages received where social security and medicare tax were neither withheld nor
+        reported on form W-2.
+        Found on Form 8919 line 6.
+        Only applicable if all of the following are true:
+        - You performed services for a firm.
+        - You believe your pay from the firm wasn’t for services as an independent contractor.
+        - The firm didn’t withhold
+        your share of social security and Medicare taxes from your pay.
+        - One of the reasons in form 8919 under Reason
+        codes applies to you.
+
+        Currently not supported. Assumes that a question verifies this form of
+        income does not apply
+        to the taxpayer.
+      </Description>
+      <TaxYear>2024</TaxYear>
+      <Derived>
+        <Dollar>0</Dollar>
+      </Derived>
+    </Fact>
+
+    <Fact path="/totalWagesSubjectToAdditionalMedicareTax">
+      <Description>Total wages subject to the additional medicare tax.
+        Found on Form 8959 line 4.
+      </Description>
+      <Derived>
+        <Round>
+          <Add>
+            <Dependency module="formW2s" path="/formW2totalMedicareWages" />
+            <Dependency path="/unreportedTipsSubjectToMedicareTax" />
+            <Dependency path="/wagesWithNoSSOrMedicareTaxWithholdings" />
+          </Add>
+        </Round>
+      </Derived>
+    </Fact>
+
     <Fact path="/medicareWagesAdditionalTaxThreshhold">
       <Name>Medicare Wages Additonal Tax Threshhold</Name>
       <Description>The filing-status based threshold at which a filer might need to pay aditional
@@ -113,6 +186,64 @@
             </Then>
           </Case>
         </Switch>
+      </Derived>
+    </Fact>
+
+    <Fact path="/wagesSubjectToAdditionalMedicareTax">
+      <Name>Wages subject to the additional medicare tax</Name>
+      <Description>The amount of wages above the threshold for applying the additional medicare tax.
+        Reported on Form
+        8959 line 6 when required.</Description>
+      <ExportZero />
+      <Derived>
+        <Switch>
+          <Case>
+            <When>
+              <GreaterThan>
+                <Left>
+                  <Dependency path="/totalWagesSubjectToAdditionalMedicareTax" />
+                </Left>
+                <Right>
+                  <Dependency path="/medicareWagesAdditionalTaxThreshhold" />
+                </Right>
+              </GreaterThan>
+            </When>
+            <Then>
+              <Subtract>
+                <Minuend>
+                  <Dependency path="/totalWagesSubjectToAdditionalMedicareTax" />
+                </Minuend>
+                <Subtrahends>
+                  <Dependency path="/medicareWagesAdditionalTaxThreshhold" />
+                </Subtrahends>
+              </Subtract>
+            </Then>
+          </Case>
+          <Case>
+            <When>
+              <True />
+            </When>
+            <Then>
+              <Dollar>0</Dollar>
+            </Then>
+          </Case>
+        </Switch>
+      </Derived>
+    </Fact>
+
+    <Fact path="/additionalMedicareTaxOnWages">
+      <Name>Additional Medicare Tax on Wages</Name>
+      <Description>The amount of the additional Medicare Tax on a taxpayer's wages.
+        Reported on Form 8959 line 7.
+      </Description>
+      <ExportZero />
+      <Derived>
+        <Round>
+          <Multiply>
+            <Dependency path="/additionalMedicareTaxRate" />
+            <Dependency path="/wagesSubjectToAdditionalMedicareTax" />
+          </Multiply>
+        </Round>
       </Derived>
     </Fact>
 

--- a/direct-file/backend/src/main/resources/tax/additionalMedicareTax.xml
+++ b/direct-file/backend/src/main/resources/tax/additionalMedicareTax.xml
@@ -1,0 +1,120 @@
+<?xml-model href="./FactDictionaryModule.rng"?>
+<FactDictionaryModule>
+  <Facts>
+    <!--
+     #############################################################
+     ### Facts to complete form 8959 - Additional Medicare Tax
+     ### At this time, only Part I and Part V of the form are supported.
+     #############################################################
+   -->
+
+    <Fact path="/maxMFSMedicareWages">
+      <Name>Maximum Medicare Wages for an MFS Filer</Name>
+      <Description>The maximum medicare wages (W-2 Box 5) a MFS filer might have without possibly
+        needing to pay
+        Additional Medicare Tax
+        Defined in 26 CFR § 31.3101-2
+      </Description>
+      <Derived>
+        <Dollar>125000</Dollar>
+      </Derived>
+    </Fact>
+
+    <Fact path="/maxMFJMedicareWages">
+      <Name>Maximum Medicare Wages for an MRJ Filer</Name>
+      <Description>The maximum medicare wages (W-2 Box 5) a MFS filer might have without possibly
+        needing to pay
+        Additional Medicare Tax
+        Defined in 26 CFR § 31.3101-2
+      </Description>
+      <Derived>
+        <Dollar>250000</Dollar>
+      </Derived>
+    </Fact>
+
+    <Fact path="/maxNonMFSorMFJMedicareWages">
+      <Name>Maximum Medicare Wages for non-MFS Filer</Name>
+      <Description>The maximum medicare wages (W-2 Box 5) filers with a status other than MFS might
+        have without possibly
+        needing to pay Additional Medicare Tax.
+        Defined in 26 CFR § 31.3101-2
+      </Description>
+      <Derived>
+        <Dollar>200000</Dollar>
+      </Derived>
+    </Fact>
+
+    <Fact path="/perW2MedicareWageThreshold">
+      <Name>Maximum Medicare Wages on a W-2 for Additional Medicare Tax</Name>
+      <Description>The maximum medicare wages (W-2 Box 5) any W-2 on a return could have
+        before needing to file Form 8959
+        to calculate the Additional Medicare Tax
+        Or potentially refund excess withholdings
+        TODO - Add test scenario for
+        MFJ, W-2 over 200k but under MFJ limit
+        TODO - Add test scenario for MFJ, Two W-2s, both under 200k but combined
+        over 200k, combined under 250k
+        See "Who must file" on form 8959 instructions.
+      </Description>
+      <Export downstreamFacts="true" />
+      <Derived>
+        <Dollar>200000</Dollar>
+      </Derived>
+    </Fact>
+
+    <Fact path="/anyW2ExceedsMaxIndividualWages">
+      <Description>The filer has at least one W-2 that triggers filing form 8959.
+      </Description>
+
+      <Derived>
+        <GreaterThan>
+          <Left>
+            <Count>
+              <Dependency module="formW2s" path="/formW2s/*/medicareWagesRequireForm8959" />
+            </Count>
+          </Left>
+          <Right>
+            <Int>0</Int>
+          </Right>
+        </GreaterThan>
+      </Derived>
+    </Fact>
+
+    <Fact path="/medicareWagesAdditionalTaxThreshhold">
+      <Name>Medicare Wages Additonal Tax Threshhold</Name>
+      <Description>The filing-status based threshold at which a filer might need to pay aditional
+        medicare taxes and
+        thereby requires Form 8959.
+        Reported on Form 8959 line 5 when required.</Description>
+      <Derived>
+        <Switch>
+          <Case>
+            <When>
+              <Dependency module="filingStatus" path="/isFilingStatusMFS" />
+            </When>
+            <Then>
+              <Dependency path="/maxMFSMedicareWages" />
+            </Then>
+          </Case>
+          <Case>
+            <When>
+              <Dependency module="filingStatus" path="/isFilingStatusMFJ" />
+            </When>
+            <Then>
+              <Dependency path="/maxMFJMedicareWages" />
+            </Then>
+          </Case>
+          <Case>
+            <When>
+              <True />
+            </When>
+            <Then>
+              <Dependency path="/maxNonMFSorMFJMedicareWages" />
+            </Then>
+          </Case>
+        </Switch>
+      </Derived>
+    </Fact>
+
+  </Facts>
+</FactDictionaryModule>

--- a/direct-file/backend/src/main/resources/tax/flow.xml
+++ b/direct-file/backend/src/main/resources/tax/flow.xml
@@ -36,7 +36,7 @@
           <Dependency module="formW2s" path="/knockoutMedicareWages" />
           <Dependency module="formW2s" path="/hasABox14NYRRTAValueWeKnockout" />
           <Dependency module="formW2s" path="/anyFilerExceedsMaxOasdiWages" />
-          <Dependency module="formW2s" path="/flowKnockoutHasRRTACodesInBox14NotInNY" />
+          <Dependency module="formW2s" path="/flowKnockoutHasRRTACodesInBox14" />
           <Dependency module="formW2s" path="/knockoutYonkersPartYear" />
           <Dependency module="form1099Rs" path="/flowKnockoutRetirementTaxableAmountNotDetermined" />
           <Dependency module="form1099Rs"

--- a/direct-file/backend/src/main/resources/tax/formW2s.xml
+++ b/direct-file/backend/src/main/resources/tax/formW2s.xml
@@ -293,48 +293,6 @@
       </Derived>
     </Fact>
 
-    <Fact path="/maxMFSMedicareWages">
-      <Name>Maximum Medicare Wages for an MFS Filer</Name>
-      <Description>The maximum medicare wages (W-2 Box 5) a MFS filer might have without possibly
-        needing to pay
-        Additional Medicare Tax</Description>
-      <Derived>
-        <Dollar>125000</Dollar>
-      </Derived>
-    </Fact>
-
-    <Fact path="/maxMFJMedicareWages">
-      <Name>Maximum Medicare Wages for an MRJ Filer</Name>
-      <Description>The maximum medicare wages (W-2 Box 5) a MFS filer might have without possibly
-        needing to pay
-        Additional Medicare Tax</Description>
-      <Derived>
-        <Dollar>250000</Dollar>
-      </Derived>
-    </Fact>
-
-    <Fact path="/maxNonMFSorMFJMedicareWages">
-      <Name>Maximum Medicare Wages for non-MFS Filer</Name>
-      <Description>The maximum medicare wages (W-2 Box 5) filers with a status other than MFS might
-        have without
-        possibly
-        needing to pay Additional Medicare Tax</Description>
-      <Derived>
-        <Dollar>200000</Dollar>
-      </Derived>
-    </Fact>
-
-    <Fact path="/maxIndividualMedicareWages">
-      <Name>Maximum Medicare Wages for non-MFS Filer</Name>
-      <Description>The maximum medicare wages (W-2 Box 5) any individual on a return could have
-        before needing to pay
-        Additonal Medicare Tax</Description>
-      <Derived>
-        <Dollar>200000</Dollar>
-      </Derived>
-    </Fact>
-
-
     <Fact path="/maxOasdiWagesOnMultipleW2sForOnePerson">
       <Name>Maximum Social Security Wages On Multiple W2s for one person</Name>
       <Description>The limit of Social Security Wages that one filer can have across multiple W2s
@@ -574,41 +532,6 @@
       </Derived>
     </Fact>
 
-    <Fact path="/medicareWagesAdditionalTaxThreshhold">
-      <Name>Medicare Wages Additonal Tax Threshhold</Name>
-      <Description>The filing-status based threshold at which a filer might need to pay aditional
-        medicare taxes and
-        thereby requires form 8959</Description>
-      <Derived>
-        <Switch>
-          <Case>
-            <When>
-              <Dependency module="filingStatus" path="/isFilingStatusMFS" />
-            </When>
-            <Then>
-              <Dependency path="/maxMFSMedicareWages" />
-            </Then>
-          </Case>
-          <Case>
-            <When>
-              <Dependency module="filingStatus" path="/isFilingStatusMFJ" />
-            </When>
-            <Then>
-              <Dependency path="/maxMFJMedicareWages" />
-            </Then>
-          </Case>
-          <Case>
-            <When>
-              <True />
-            </When>
-            <Then>
-              <Dependency path="/maxNonMFSorMFJMedicareWages" />
-            </Then>
-          </Case>
-        </Switch>
-      </Derived>
-    </Fact>
-
     <Fact path="/knockoutMedicareWages">
       <Name>Knockout if Medicare Wages Great Than Max for filing status</Name>
       <Description>Knockout the filer if their total medicare wages are above the limit for their
@@ -618,13 +541,13 @@
 
       <Derived>
         <Any>
-          <Dependency path="/anyFilerExceedsEligibleForMedicareWagesCredit" />
+          <Dependency module="additionalMedicareTax" path="/anyW2ExceedsMaxIndividualWages" />
           <GreaterThan>
             <Left>
               <Dependency path="/formW2totalMedicareWages" />
             </Left>
             <Right>
-              <Dependency path="/medicareWagesAdditionalTaxThreshhold" />
+              <Dependency module="additionalMedicareTax" path="/medicareWagesAdditionalTaxThreshhold" />
             </Right>
           </GreaterThan>
         </Any>
@@ -669,7 +592,7 @@
         entitle them to a socail security refund?</Description>
       <Derived>
         <All>
-          <!-- Does the primary filer have multiple W2s -->
+          <!-- Does the secondary filer have multiple W2s -->
           <GreaterThan>
             <Left>
               <Dependency path="/secondaryFilerW2sCount"></Dependency>
@@ -1356,13 +1279,35 @@
       </Derived>
     </Fact>
 
+    <Fact path="/formW2s/*/medicareWagesRequireForm8959">
+      <Description>If any single W-2 has medicare wages in Box 5 that exceed a per-W2 threshold, the filer
+        must file form
+        8959.</Description>
+      <Export downstreamFacts="true" />
+      <Derived>
+        <GreaterThan>
+          <Left>
+            <Dependency path="../medicareWages" />
+          </Left>
+          <Right>
+            <Dependency module="additionalMedicareTax" path="/perW2MedicareWageThreshold" />
+          </Right>
+        </GreaterThan>
+      </Derived>
+    </Fact>
+
     <Fact path="/formW2totalMedicareWages">
       <Name>Total Medicare Wages</Name>
-      <Description>The sum of all medicare wages across Form W-2s</Description>
+      <Description>The sum of all medicare wages across Form W-2s.
+        This is shown on Box 1 of Form 8959 when that form is
+        required to be filed.
+      </Description>
       <Derived>
-        <CollectionSum>
-          <Dependency path="/formW2s/*/medicareWages"></Dependency>
-        </CollectionSum>
+        <Round>
+          <CollectionSum>
+            <Dependency path="/formW2s/*/medicareWages"></Dependency>
+          </CollectionSum>
+        </Round>
       </Derived>
     </Fact>
 

--- a/direct-file/backend/src/main/resources/tax/formW2s.xml
+++ b/direct-file/backend/src/main/resources/tax/formW2s.xml
@@ -506,6 +506,27 @@
       </Derived>
     </Fact>
 
+    <Fact path="/flowKnockoutHasRRTACodesInBox14">
+      <Name>Knockout due to having RRTA codes in Box 14</Name>
+      <Description>Everyone with RRTA codes in Box 14 gets KO'ed. Even in NY.</Description>
+      <Export downstreamFacts="true" />
+
+      <Derived>
+        <GreaterThan>
+          <Left>
+            <CollectionSize>
+              <Filter path="/formW2s">
+                <Dependency path="hasRRTACodesInBox14" />
+              </Filter>
+            </CollectionSize>
+          </Left>
+          <Right>
+            <Int>0</Int>
+          </Right>
+        </GreaterThan>
+      </Derived>
+    </Fact>
+
     <Fact path="/flowKnockoutHasRRTACodesInBox14NotInNY">
       <Name>Knockout Due to having RRTA codes in Box 14</Name>
       <Description>Knockout Due to having RRTA codes in Box 14</Description>
@@ -513,18 +534,7 @@
 
       <Derived>
         <All>
-          <GreaterThan>
-            <Left>
-              <CollectionSize>
-                <Filter path="/formW2s">
-                  <Dependency path="hasRRTACodesInBox14" />
-                </Filter>
-              </CollectionSize>
-            </Left>
-            <Right>
-              <Int>0</Int>
-            </Right>
-          </GreaterThan>
+          <Dependency path="/flowKnockoutHasRRTACodesInBox14"></Dependency>
           <Not>
             <Dependency module="filers" path="/livedInNy"></Dependency>
           </Not>

--- a/direct-file/backend/src/main/resources/tax/formW2s.xml
+++ b/direct-file/backend/src/main/resources/tax/formW2s.xml
@@ -1339,61 +1339,6 @@
       </Derived>
     </Fact>
 
-
-    <Fact path="/anyFilerExceedsEligibleForMedicareWagesCredit">
-      <Description>Is any filer on the return over the limit that would qualify them for a credit
-        for their medicare
-        payments. Note this would only trigger if the filers are MFJ, since for non-MFJ filers, the
-        limit would trigger
-        anyway</Description>
-      <Derived>
-        <All>
-          <Dependency module="filingStatus" path="/isFilingStatusMFJ" />
-          <Any>
-            <GreaterThan>
-              <Left>
-                <Dependency path="/primaryFilerMedicareWages" />
-              </Left>
-              <Right>
-                <Dependency path="/maxIndividualMedicareWages" />
-              </Right>
-            </GreaterThan>
-            <GreaterThan>
-              <Left>
-                <Dependency path="/secondaryFilerMedicareWages" />
-              </Left>
-              <Right>
-                <Dependency path="/maxIndividualMedicareWages" />
-              </Right>
-            </GreaterThan>
-          </Any>
-        </All>
-      </Derived>
-    </Fact>
-
-    <Fact path="/anyFilerRequiredToPayExtraMedicareTax">
-      <Description>
-        Is any filer over the medicare tax threshhold such that they'd qualify for a refund of some
-        of the
-        medicare tax they paid.
-      </Description>
-      <Derived>
-        <All>
-          <Dependency path="/knockoutMedicareWages" />
-          <Any>
-            <Not>
-              <IsComplete>
-                <Dependency path="/anyFilerExceedsEligibleForMedicareWagesCredit" />
-              </IsComplete>
-            </Not>
-            <Not>
-              <Dependency path="/anyFilerExceedsEligibleForMedicareWagesCredit" />
-            </Not>
-          </Any>
-        </All>
-      </Derived>
-    </Fact>
-
     <Fact path="/maxMedicareWagesForAnyFilerOnReturn">
       <Description>The highest medicare wages a single person on the return recieved</Description>
       <Derived>

--- a/direct-file/backend/src/main/resources/tax/schedule2.xml
+++ b/direct-file/backend/src/main/resources/tax/schedule2.xml
@@ -49,5 +49,37 @@
         </Switch>
       </Derived>
     </Fact>
+
+    <Fact path="/hasAdditionsToTax">
+      <Description>True if any of the additions to tax reported on Line 3 of schedule 2 apply.</Description>
+      <Derived>
+        <Switch>
+          <Case>
+            <When>
+              <GreaterThan>
+                <Left>
+                  <Dependency path="/totalAdditionalTaxesOwed" />
+                </Left>
+                <Right>
+                  <Dollar>0</Dollar>
+                </Right>
+              </GreaterThan>
+            </When>
+            <Then>
+              <True />
+            </Then>
+          </Case>
+          <Case>
+            <When>
+              <True />
+            </When>
+            <Then>
+              <False />
+            </Then>
+          </Case>
+        </Switch>
+      </Derived>
+    </Fact>
+
   </Facts>
 </FactDictionaryModule>

--- a/direct-file/df-client/df-client-app/src/flow/flow-chunks/your-taxes/AmountSubcategory.tsx
+++ b/direct-file/df-client/df-client-app/src/flow/flow-chunks/your-taxes/AmountSubcategory.tsx
@@ -108,11 +108,11 @@ export const AmountSubcategory = (
             itemKey: `excessAdvancePTC`,
           },
           {
-            itemKey: `addtionalTaxes`,
+            itemKey: `additionalTaxes`,
             showTopBorder: true,
           },
         ]}
-        condition={`/owesPtc`}
+        condition={`/hasAdditionsToTax`}
       />
       <SummaryTable
         i18nKey='/info/your-taxes/amount/tax-amount-explanation-credits'

--- a/direct-file/df-client/df-client-app/src/locales/en.yaml
+++ b/direct-file/df-client/df-client-app/src/locales/en.yaml
@@ -11699,7 +11699,7 @@ info:
             modals:
               text: <sharedModalExcessAptc>Excess advance PTC repayment</sharedModalExcessAptc>
         td: "+{{/lesserOfNetPtcAmountAndRepaymentLimitation}}"
-      addtionalTaxes:
+      additionalTaxes:
         th: <strong>Initial tax amount with additional taxes</strong>
         td: <strong>{{/totalTentativeTax}}</strong>
   /info/your-taxes/amount/tax-amount-explanation-credits:

--- a/direct-file/df-client/df-client-app/src/locales/es.yaml
+++ b/direct-file/df-client/df-client-app/src/locales/es.yaml
@@ -7113,7 +7113,7 @@ info:
             modals:
               text: <sharedModalExcessAptc>PTC avanzado en exceso que debes devolver</sharedModalExcessAptc>
         td: "+{{/lesserOfNetPtcAmountAndRepaymentLimitation}}"
-      addtionalTaxes:
+      additionalTaxes:
         th: <strong>Cantidad del impuesto inicial con los impuestos adicionales</strong>
         td: <strong>{{/totalTentativeTax}}</strong>
   /info/your-taxes/amount/tax-amount-explanation-credits:


### PR DESCRIPTION
## Description

This PR adds facts to the dictionary that add preliminary support for the Additional Medicare Tax.  It's not really stand-alone, but for simplicity of following the thread of changes, I think it better to include now.

I'm breaking my own guidance on including tests as I go. These should get more thorough automated tests before fully moving on to other things.

### What changed

Added new facts to support Part I of form 8959.  Some of these were already present in the W2 module, and since there will be several more, it makes sense to me to start a new module just for the Alternative Minimum Tax.

### Motivation and context

This lays groundwork for supporting taxpayers whose income exceeds the limit for paying the Additional Medicare Tax. While most of those folks can probably afford to pay for tax preparation services, this is a relatively low hanging task. All the information is already collected, so we can support this use case without any new screens or writable facts.

## Tests

### Scala tests (if applicable)

N/A

### Fact dictionary tests (for all changes)

- [ ] ~~I have added fact dictionary tests as appropriate.~~ (I did not, making this a TODO item)
- [x] I have run `npm run generate-fact-dictionary` from `/direct-file-factgraph/direct-file/df-client/df-client-app`
- [x] I have run `npm run test factDictionaryTests` from `/direct-file-factgraph/direct-file/df-client/df-client-app/src/test` and all tests pass.

### Manual tests

Have manually tested this in combination with PRs that follow and received correct calculations for a non-comprehensive set of test cases.

## Is there anything reviewers should look at carefully?

Accuracy compared to the form and instructions.

## Are there any loose ends or TODO items for the future?

Yep - definitely needs fact dictionary tests to support it (and the rest of the form!)