### PR TITLE
Remove knockouts for the Additional Medicare Tax

### DIFF
--- a/direct-file/backend/src/main/resources/tax/flow.xml
+++ b/direct-file/backend/src/main/resources/tax/flow.xml
@@ -33,7 +33,6 @@
           <Dependency module="formW2s" path="/flowKnockoutThirdPartySickPay" />
           <Dependency module="formW2s" path="/flowKnockoutBox15IncomeFromDifferentState" />
           <Dependency module="formW2s" path="/flowKnockoutNonQualifiedPlans" />
-          <Dependency module="formW2s" path="/knockoutMedicareWages" />
           <Dependency module="formW2s" path="/hasABox14NYRRTAValueWeKnockout" />
           <Dependency module="formW2s" path="/anyFilerExceedsMaxOasdiWages" />
           <Dependency module="formW2s" path="/flowKnockoutHasRRTACodesInBox14" />

--- a/direct-file/backend/src/main/resources/tax/formW2s.xml
+++ b/direct-file/backend/src/main/resources/tax/formW2s.xml
@@ -542,29 +542,6 @@
       </Derived>
     </Fact>
 
-    <Fact path="/knockoutMedicareWages">
-      <Name>Knockout if Medicare Wages Great Than Max for filing status</Name>
-      <Description>Knockout the filer if their total medicare wages are above the limit for their
-        filing status that
-        might necessitate form 8959</Description>
-      <Export downstreamFacts="true" />
-
-      <Derived>
-        <Any>
-          <Dependency module="additionalMedicareTax" path="/anyW2ExceedsMaxIndividualWages" />
-          <GreaterThan>
-            <Left>
-              <Dependency path="/formW2totalMedicareWages" />
-            </Left>
-            <Right>
-              <Dependency module="additionalMedicareTax" path="/medicareWagesAdditionalTaxThreshhold" />
-            </Right>
-          </GreaterThan>
-        </Any>
-      </Derived>
-    </Fact>
-
-
     <Fact path="/primaryFilerExceedsMaxOasdiWages">
       <Name>Primary Filer Exceeds Max Social Security Wages</Name>
       <Description>Does the primary filer have Great Than 1 W-2 and social security wages over the

--- a/direct-file/backend/src/main/resources/tax/imported.xml
+++ b/direct-file/backend/src/main/resources/tax/imported.xml
@@ -527,7 +527,6 @@
       <Derived>
         <Any>
           <Dependency module="formW2s" path="/anyFilerExceedsMaxOasdiWages" />
-          <Dependency module="formW2s" path="/knockoutMedicareWages" />
           <Dependency module="formW2s" path="/flowKnockoutAllocatedTips" />
           <Dependency module="formW2s" path="/flowKnockoutNonQualifiedPlans" />
           <Dependency module="formW2s" path="/knockoutForBox12Value" />

--- a/direct-file/df-client/df-client-app/src/flow/flow-chunks/income/JobIncomeSubcategory.tsx
+++ b/direct-file/df-client/df-client-app/src/flow/flow-chunks/income/JobIncomeSubcategory.tsx
@@ -266,25 +266,6 @@ export const JobIncomeSubcategory = (
             batches={[`data-import-w2`]}
           />
           <DFAccordion
-            i18nKey='/info/knockout/medicare-wages-accordion-mfs'
-            conditions={[{ condition: `/knockoutMedicareWages` }, { condition: `/isFilingStatusMFS` }]}
-            batches={[`data-import-w2`]}
-          />
-          <DFAccordion
-            i18nKey='/info/knockout/medicare-wages-accordion-mfj'
-            conditions={[{ condition: `/knockoutMedicareWages` }, { condition: `/isFilingStatusMFJ` }]}
-            batches={[`data-import-w2`]}
-          />
-          <DFAccordion
-            i18nKey='/info/knockout/medicare-wages-accordion-single'
-            conditions={[
-              { condition: `/knockoutMedicareWages` },
-              { operator: `isFalse`, condition: `/isFilingStatusMFJ` },
-              { operator: `isFalse`, condition: `/isFilingStatusMFS` },
-            ]}
-            batches={[`data-import-w2`]}
-          />
-          <DFAccordion
             i18nKey='/info/knockout/allocated-tips-primary-filer-accordion'
             condition='/formW2WithAllocatedTips'
             batches={[`data-import-w2`]}
@@ -605,35 +586,6 @@ export const JobIncomeSubcategory = (
           <DFAlert i18nKey='/info/knockout/generic-other-ways-to-file' headingLevel='h2' type='warning' />
           <KnockoutButton i18nKey='button.knockout' />
         </Screen>
-        <Gate condition='/knockoutMedicareWages'>
-          <Screen route='medicare-wages-ko' condition='/anyFilerRequiredToPayExtraMedicareTax' isKnockout={true}>
-            <IconDisplay name='ErrorOutline' size={9} isCentered />
-            <Heading i18nKey='/heading/knockout/medicare-wages-mfj' condition='/isFilingStatusMFJ' />
-            <Heading
-              i18nKey='/heading/knockout/medicare-wages'
-              condition={{ operator: `isFalseOrIncomplete`, condition: `/isFilingStatusMFJ` }}
-            />
-            <InfoDisplay
-              i18nKey='/info/knockout/medicare-wages'
-              condition={{ operator: `isFalseOrIncomplete`, condition: `/isFilingStatusMFJ` }}
-            />
-            <InfoDisplay i18nKey='/info/knockout/medicare-wages-mfj' condition='/isFilingStatusMFJ' />
-            <DFAlert i18nKey='/info/knockout/generic-other-ways-to-file' headingLevel='h2' type='warning' />
-            <KnockoutButton i18nKey='button.knockout' />
-          </Screen>
-          <Screen
-            route='medicare-wages-ko-credit'
-            condition='/anyFilerExceedsEligibleForMedicareWagesCredit'
-            isKnockout={true}
-          >
-            <IconDisplay name='ErrorOutline' size={9} isCentered />
-            <Heading i18nKey='/heading/knockout/medicare-wages-credit' />
-            <InfoDisplay i18nKey='/info/knockout/medicare-wages-credit' />
-            <DFAlert i18nKey='/info/knockout/generic-other-ways-to-file' headingLevel='h2' type='warning' />
-
-            <KnockoutButton i18nKey='button.knockout' />
-          </Screen>
-        </Gate>
         <Screen route='w2-allocated-tips-ko' condition='/flowKnockoutAllocatedTips' isKnockout={true}>
           <IconDisplay name='ErrorOutline' size={9} isCentered />
           <Heading i18nKey='/heading/knockout/forms-missing/allocated-tips' />

--- a/direct-file/df-client/df-client-app/src/locales/en.yaml
+++ b/direct-file/df-client/df-client-app/src/locales/en.yaml
@@ -2683,11 +2683,6 @@ headings:
     the Presidential Election Campaign Fund?
   /heading/other-preferences/create-self-select-pin: Create a Self-Select PIN to confirm your identity next year.
   /heading/federal-tax-return: "{{/taxYear}} federal tax return details"
-  /heading/knockout/medicare-wages: Direct File doesn’t yet support the amount of income you received.
-  /heading/knockout/medicare-wages-mfj:
-    Direct File doesn’t yet support the amount of income you and your spouse received.
-  /heading/knockout/medicare-wages-credit:
-    Direct File doesn’t yet support the amount of income you or your spouse received.
   /heading/knockout/add-person-born-died-no-tin: Direct File doesn’t support this yet
   /heading/knockout/no-payments-or-credit:
     Based on your responses, you don’t need to file a federal tax return for {{/taxYear}}.
@@ -12521,47 +12516,6 @@ info:
   /info/knockout/income/jobs/w2-part-year-yonkers-ko:
     body: >-
       You earned income in Yonkers but didn’t live in Yonkers, or you lived in Yonkers for only part of {{/taxYear}}.
-  /info/knockout/medicare-wages:
-    heading: Box 5 - Medicare wages and tips
-    body: >-
-      You received {{/formW2totalMedicareWages}} in Medicare wages. This tool doesn’t yet support Medicare wages over
-      {{/medicareWagesAdditionalTaxThreshhold}} for your filing status of {{/filingStatusCapitalized}}, as you may be
-      required to pay Additional Medicare Tax.
-  /info/knockout/medicare-wages-accordion-mfs:
-    heading: Box 5 - Medicare wages and tips
-    body:
-      - p: Direct File doesn’t yet support the amount of income you received.
-      - p:
-          You received {{/formW2totalMedicareWages}} in Medicare wages. This tool doesn’t yet support Medicare wages
-          over $125,000 for your filing status of Married Filing Separately, as you may be required to pay Additional
-          Medicare Tax.
-  /info/knockout/medicare-wages-mfj:
-    body: >-
-      You received {{/formW2totalMedicareWages}} in Medicare wages. This tool doesn’t yet support Medicare wages over
-      {{/medicareWagesAdditionalTaxThreshhold}} for your filing status of {{/filingStatusCapitalized}}, as you may be
-      required to pay Additional Medicare Tax.
-  /info/knockout/medicare-wages-accordion-mfj:
-    heading: Box 5 - Medicare wages and tips
-    body:
-      - p: Direct File doesn’t yet support the amount of income you and your spouse received.
-      - p:
-          You received {{/formW2totalMedicareWages}} in Medicare wages. This tool doesn’t yet support Medicare wages
-          over $250,000 for your filing status of Married Filing Jointly, as you may be required to pay Additional
-          Medicare Tax.
-  /info/knockout/medicare-wages-accordion-single:
-    heading: Box 5 - Medicare wages and tips
-    body:
-      - p: Direct File doesn’t yet support the amount of income you received.
-      - p:
-          You received {{/formW2totalMedicareWages}} in Medicare wages. This tool doesn’t yet support Medicare wages
-          over $200,000 for your filing status of {{/filingStatus}}, as you may be required to pay Additional Medicare
-          Tax.
-
-  /info/knockout/medicare-wages-credit:
-    body: >-
-      You or your spouse received {{/maxMedicareWagesForAnyFilerOnReturn}}. This tool doesn’t yet support Medicare wages
-      over {{/maxIndividualMedicareWages}} for 1 person for your filing status of {{/filingStatusCapitalized}} as you
-      may be eligible for a credit for any withheld Additional Medicare Tax.
   /info/knockout/retirement/1099-r-allocable-irr:
     body:
       - p:

--- a/direct-file/df-client/df-client-app/src/locales/es.yaml
+++ b/direct-file/df-client/df-client-app/src/locales/es.yaml
@@ -8121,23 +8121,6 @@ info:
       {{/maxOasdiWagesOnMultipleW2sForOnePerson}} en salarios del Seguro Social de más de un empleador, ya que es
       posible que este contribuyente haya pagado demasiados impuestos del Seguro Social.
     heading: Casilla 3 - Salarios del Seguro Social
-  /info/knockout/medicare-wages:
-    body: >-
-      Recibiste {{/formW2totalMedicareWages}} en salarios de Medicare. Esta herramienta aún no permite salarios de
-      Medicare de más de {{/medicareWagesAdditionalTaxThreshhold}} para tu estado civil tributario de
-      {{/filingStatusCapitalized}}, ya que es posible que debas pagar un impuesto adicional de Medicare.
-    heading: Casilla 5 - Salarios y propinas sujetos al impuesto de Medicare
-  /info/knockout/medicare-wages-mfj:
-    body: >-
-      Recibieron {{/formW2totalMedicareWages}} en salarios de Medicare. Esta herramienta aún no permite salarios de
-      Medicare de más de {{/medicareWagesAdditionalTaxThreshhold}} para el estado civil tributario de
-      {{/filingStatusCapitalized}}, ya que es posible que debas pagar un impuesto adicional de Medicare.
-  /info/knockout/medicare-wages-credit:
-    body: >-
-      Tú o tu cónyuge recibieron {{/maxMedicareWagesForAnyFilerOnReturn}} en salarios de Medicare. Esta herramienta aún
-      no permite salarios de Medicare de más de {{/maxIndividualMedicareWages}} para el estado civil tributario de
-      {{/filingStatusCapitalized}}, ya que podrías ser elegible para un crédito para cualquier impuesto adicional de
-      Medicare retenido.
   /info/knockout/income-sources-supported:
     alertText:
       body:
@@ -14648,31 +14631,6 @@ info:
   /info/knockout/social-security-wages-accordion:
     heading: Casilla 3 - Salarios del Seguro Social
     body: Direct File aún no permite la cantidad de ingresos que recibiste.
-  /info/knockout/medicare-wages-accordion-mfs:
-    heading: Casilla 5 - Salarios y propinas sujetos al impuesto de Medicare
-    body:
-      - p: Direct File aún no permite la cantidad de ingresos que recibiste.
-      - p: >-
-          Recibiste {{/formW2totalMedicareWages}} en salarios sujetos al impuesto de Medicare. Esta herramienta todavía
-          no acepta esos salarios Medicare mayores de $125,000 para tu estado civil tributario de ’Casado que presenta
-          una declaración por separado’, ya que es posible que se te requiera pagar un impuesto adicional de Medicare.
-  /info/knockout/medicare-wages-accordion-mfj:
-    heading: Casilla 5 - Salarios y propinas sujetos al impuesto de Medicare
-    body:
-      - p: >-
-          Direct File aún no permite la cantidad de ingresos que tú y tu cónyuge recibieron.
-      - p: >-
-          Recibieron {{/formW2totalMedicareWages}} en salarios sujetos al impuesto de Medicare. Esta herramienta todavía
-          no acepta esos salarios Medicare mayores de $250,000 para tu estado civil tributario de ’Casado que presenta
-          una declaración conjunta’, ya que es posible que se te requiera pagar un impuesto adicional de Medicare.
-  /info/knockout/medicare-wages-accordion-single:
-    heading: Casilla 5 - Salarios y propinas sujetos al impuesto de Medicare
-    body:
-      - p: Direct File aún no permite la cantidad de ingresos que recibiste.
-      - p: >-
-          Recibiste {{/formW2totalMedicareWages}} en salarios sujetos al impuesto de Medicare. Esta herramienta todavía
-          no acepta esos salarios Medicare mayores de $200,000 para tu estado civil tributario de ’{{/filingStatus}}’,
-          ya que es posible que se te requiera pagar un impuesto adicional de Medicare.
   /info/knockout/allocated-tips-primary-filer-accordion:
     heading: Casilla 8 - Propinas asignadas
     body:
@@ -20692,11 +20650,6 @@ headings:
   /heading/knockout/forms-missing/w2-box-14-with-rrta-codes-not-in-ny-ko: >-
     Direct File aún no permite los formularios requeridos para declarar la compensación de la Ley de Jubilación de
     Empleados Ferroviarios (RRTA, por sus siglas en inglés).
-  /heading/knockout/medicare-wages-mfj: >-
-    Direct File aún no permite la cantidad de ingresos que tú y tu cónyuge recibieron.
-  /heading/knockout/medicare-wages: Direct File aún no permite la cantidad de ingresos que recibiste.
-  /heading/knockout/medicare-wages-credit: >-
-    Direct File aún no permite la cantidad de ingresos que tú o tu cónyuge recibieron.
   /heading/knockout/income-sources-supported: >-
     Direct File no permite todos los formularios necesarios para declarar todos los tipos de ingresos.
   /heading/knockout/forms-missing/allocated-tips: >-


### PR DESCRIPTION
## Description

Allow users to proceed when they are required to pay the Additional Medicare Tax

### What changed

Removed knockouts and text that is no longer needed now that filers can report their Additional Medicare Tax via Form 8959.

### Motivation and context

Part 3 of steps to enable the Additional Medicare Tax.  This one unlocks testing in the front end by removing the barriers to reporting in Form 8959.

## Tests

### Scala tests (if applicable)

N/A

### Fact dictionary tests (for all changes)

- [x] I have added fact dictionary tests as appropriate.
- [x] I have run `npm run generate-fact-dictionary` from `/direct-file-factgraph/direct-file/df-client/df-client-app`
- [x] I have run `npm run test factDictionaryTests` from `/direct-file-factgraph/direct-file/df-client/df-client-app/src/test` and all tests pass.

### Manual tests

Have manually tested after updating PDFs (a couple of PRs ahead of this one)

## Is there anything reviewers should look at carefully?

Not that I know of

## Are there any loose ends or TODO items for the future?

- Frontend still needs to show user the tax calculations when Other Taxes can be applied
- PDF generation needs to be updated to include Form 8959 when appropriate.