### PR TITLE
Display medicare tax in frontend calculations

### DIFF
--- a/direct-file/backend/src/main/resources/tax/schedule2.xml
+++ b/direct-file/backend/src/main/resources/tax/schedule2.xml
@@ -96,5 +96,40 @@
       </Derived>
     </Fact>
 
+    <Fact path="/hasOtherTaxes">
+      <Description>True if any of the other taxes reported on Line 21 of schedule 2 apply.
+        Not used to calculate taxes,
+        but is used to determine what to display to the
+        user in the frontend.
+      </Description>
+      <Derived>
+        <Switch>
+          <Case>
+            <When>
+              <GreaterThan>
+                <Left>
+                  <Dependency path="/totalOtherTaxes" />
+                </Left>
+                <Right>
+                  <Dollar>0</Dollar>
+                </Right>
+              </GreaterThan>
+            </When>
+            <Then>
+              <True />
+            </Then>
+          </Case>
+          <Case>
+            <When>
+              <True />
+            </When>
+            <Then>
+              <False />
+            </Then>
+          </Case>
+        </Switch>
+      </Derived>
+    </Fact>
+
   </Facts>
 </FactDictionaryModule>

--- a/direct-file/backend/src/main/resources/tax/taxCalculations.xml
+++ b/direct-file/backend/src/main/resources/tax/taxCalculations.xml
@@ -1589,8 +1589,11 @@
 
     <Fact path="/taxWithCreditsApplied">
       <Name>Tax With Credits Applied</Name>
-      <Description>The amount that total payments exceed total taxes. Report on line 34 of Form
-        1040.</Description>
+      <Description>The amount of taxes after applying nonrefundable credits to the total tax.
+        This does not correspond to
+        a single line on Form 1040, but it is equivalent to
+        subtracting 1040 line 32 from line 24.
+      </Description>
 
       <Derived>
         <Subtract>

--- a/direct-file/df-client/df-client-app/src/flow/flow-chunks/income/JobIncomeSubcategory.tsx
+++ b/direct-file/df-client/df-client-app/src/flow/flow-chunks/income/JobIncomeSubcategory.tsx
@@ -763,7 +763,7 @@ export const JobIncomeSubcategory = (
           <SaveAndOrContinueButton />
         </Screen>
         <Gate condition='/formW2s/*/hasBox14Codes'>
-          <Screen route='w2-add-box-14' condition={{ operator: `isFalse`, condition: `/flowStateToolNeedsBox14` }}>
+          <Screen route='w2-add-box-14'>
             <ContextHeading
               displayOnlyOn='edit'
               i18nKey='/heading/income/jobs/w2-data-import-review'
@@ -776,7 +776,7 @@ export const JobIncomeSubcategory = (
             <Boolean path='/formW2s/*/hasRRTACodes' />
             <SaveAndOrContinueButton />
           </Screen>
-          <Screen route='rrta-codes-ko' condition='/flowKnockoutHasRRTACodesInBox14NotInNY' isKnockout={true}>
+          <Screen route='rrta-codes-ko' condition='/flowKnockoutHasRRTACodesInBox14' isKnockout={true}>
             <IconDisplay name='ErrorOutline' size={9} isCentered />
             <Heading i18nKey='/heading/knockout/forms-missing/w2-box-14-with-rrta-codes-not-in-ny-ko' />
             <DFAlert i18nKey='/info/knockout/generic-other-ways-to-file' headingLevel='h2' type='warning' />

--- a/direct-file/df-client/df-client-app/src/flow/flow-chunks/your-taxes/AmountSubcategory.tsx
+++ b/direct-file/df-client/df-client-app/src/flow/flow-chunks/your-taxes/AmountSubcategory.tsx
@@ -115,8 +115,7 @@ export const AmountSubcategory = (
         condition={`/hasAdditionsToTax`}
       />
       <SummaryTable
-        i18nKey='/info/your-taxes/amount/tax-amount-explanation-credits'
-        batches={[`ptc-1`]}
+        i18nKey='/info/your-taxes/amount/tax-amount-explanation-nonrefundable-credits'
         items={[
           {
             itemKey: `nonrefundableCredits`,
@@ -147,6 +146,28 @@ export const AmountSubcategory = (
             conditions: [`/isReceivingSaversCredit`],
             indent: true,
           },
+          {
+            itemKey: `taxAmount`,
+            showTopBorder: true,
+          },
+        ]}
+      />
+      <SummaryTable
+        i18nKey='/info/your-taxes/amount/tax-amount-explanation-with-other-taxes'
+        items={[
+          {
+            itemKey: `additionalMedicareTax`,
+          },
+          {
+            itemKey: `taxAmount`,
+            showTopBorder: true,
+          },
+        ]}
+        condition={`/hasOtherTaxes`}
+      />
+      <SummaryTable
+        i18nKey='/info/your-taxes/amount/tax-amount-explanation-refundable-credits'
+        items={[
           {
             itemKey: `refundableCredits`,
             conditions: [`/isReceivingRefundableCredits`],

--- a/direct-file/df-client/df-client-app/src/locales/en.yaml
+++ b/direct-file/df-client/df-client-app/src/locales/en.yaml
@@ -11697,10 +11697,10 @@ info:
       additionalTaxes:
         th: <strong>Initial tax amount with additional taxes</strong>
         td: <strong>{{/totalTentativeTax}}</strong>
-  /info/your-taxes/amount/tax-amount-explanation-credits:
+  /info/your-taxes/amount/tax-amount-explanation-nonrefundable-credits:
     sections:
-      explainer: Then we applied your credits
-      caption: Tax amount with tax credits applied
+      explainer: Then we applied your nonrefundable credits
+      caption: Tax amount with nonrefundable credits applied
       nonrefundableCredits:
         helpText:
           modals:
@@ -11738,6 +11738,27 @@ info:
       savers:
         th: Saver’s Credit
         td: "-{{/qualifiedSaverCreditAmount}}"
+      taxAmount:
+        th: <strong>Tax amount with nonrefundable credits applied</strong>
+        td: <strong>{{/taxLessNonRefundableCredits}}</strong>
+  /info/your-taxes/amount/tax-amount-explanation-with-other-taxes:
+    sections:
+      explainer:
+        body: Then we added other taxes that cannot be offset by nonrefundable credits
+      caption: Tax amount after applying other taxes
+      additionalMedicareTax:
+        th:
+          helpText:
+            modals:
+              text: Additional Medicare Tax
+        td: "+{{/totalAdditionalMedicareTax}}"
+      taxAmount:
+        th: <strong>Tax amount after applying other taxes</strong>
+        td: <strong>{{/totalTax}}</strong>
+  /info/your-taxes/amount/tax-amount-explanation-refundable-credits:
+    sections:
+      explainer: Then we applied your nonrefundable credits
+      caption: Tax amount with refundable credits applied
       refundableCredits:
         helpText:
           modals:
@@ -11765,7 +11786,7 @@ info:
         th: Earned Income Tax Credit
         td: "-{{/earnedIncomeCredit}}"
       taxAmount:
-        th: <strong>Tax amount with credits applied</strong>
+        th: <strong>Tax amount with refundable credits applied</strong>
         td: <strong>{{/taxWithCreditsApplied}}</strong>
   /info/your-taxes/amount/tax-amount-explanation-final:
     sections:


### PR DESCRIPTION
## Description

### What changed

Show users how we applied the Additional Medicare Tax calculations. For example:

<img width="653" alt="Screenshot 2025-06-27 at 4 57 26 PM" src="https://github.com/user-attachments/assets/dc30648e-49b0-4d97-a138-a8ca78f28369" />

### Motivation and context

Makes it easier to see the tax calculations and test any facts that involve total other taxes

## Tests

### Scala tests (if applicable)

N/A

### Fact dictionary tests (for all changes)

N/A

### Manual tests

Manually verified that the amounts were correct for a small sample of test cases

## Is there anything reviewers should look at carefully?

No

## Are there any loose ends or TODO items for the future?

PDF support for the Additional Medicare Tax + automated tests